### PR TITLE
Hotfix: Fixed Import Path In package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         ".": {
             "import": {
                 "types": "./dist/index.d.ts",
-                "default": "./dist/js.js"
+                "default": "./dist/index.js"
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pixi-input-map",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Pixi Input Map is used to manage input actions which are named events tied to a key or mouse button.",
     "author": "Robert Corponoi",
     "license": "MIT",


### PR DESCRIPTION
- The import path was incorrectly set to `"./dist/js.js"` and needed to be changed to `"./dist/index.js"`.